### PR TITLE
added comma in configuratios files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
               docker-kafka-server {
                   properties {
                     bootstrap.servers: "kafka:9092"
-                  }
+                  },
                   registry: "http://schema-registry:8085"
               }
             }


### PR DESCRIPTION
Got the following errror when running kafkahq with docker-compose

```
kafkahq_1  | 2019-02-13 13:41:56,893  INFO main       org.kafkahq.App            Stopped
kafkahq_1  | 2019-02-13 13:41:56,902 ERROR main       org.kafkahq.App            An error occurred while starting the application:
kafkahq_1  | com.typesafe.config.ConfigException$Parse: /app/application.conf: 1: Expecting close brace } or a comma, got 'registry' (if you intended 'registry' to be part of a key or string value, try enclosing the key or value in double quotes)
kafkahq_1  | 	at com.typesafe.config.impl.ConfigDocumentParser$ParseContext.parseError(ConfigDocumentParser.java:201)
kafkahq_1  | 	at com.typesafe.config.impl.ConfigDocumentParser$ParseContext.parseError(ConfigDocumentParser.java:197)
kafkahq_1  | 	at com.typesafe.config.impl.ConfigDocumentParser$ParseContext.parseObject(ConfigDocumentParser.java:528)
kafkahq_1  | 	at com.typesafe.config.impl.ConfigDocumentParser$ParseContext.parseValue(ConfigDocumentParser.java:247)
```