### PR TITLE
[WIP] Add a topic regex to basic auth

### DIFF
--- a/application.example.yml
+++ b/application.example.yml
@@ -1,8 +1,8 @@
 kafkahq:
   server:
     base-path: "" # if behind a reverse proxy, path to kafkahq with trailing slash (optional). Example: kafkahq is
-                  # behind a reverse proxy with url http://my-server/kafkahq, set base-path: "/kafkahq/".
-                  # Not needed if you're behind a reverse proxy with subdomain http://kafkahq.my-server/
+      # behind a reverse proxy with url http://my-server/kafkahq, set base-path: "/kafkahq/".
+    # Not needed if you're behind a reverse proxy with subdomain http://kafkahq.my-server/
     access-log: # Access log configuration (optional)
       enabled: true # true by default
       name: org.kafkahq.log.access # Logger name
@@ -110,5 +110,4 @@ kafkahq:
         password: pass # Password in sha256
         roles: # Role for current users
           - topic/read
-          - group/read
-          - group/delete
+        topics: ".*" # Regex to filter the topics this user can see

--- a/src/main/java/org/kafkahq/configs/BasicAuth.java
+++ b/src/main/java/org/kafkahq/configs/BasicAuth.java
@@ -14,6 +14,7 @@ public class BasicAuth {
     String username;
     String password;
     List<String> roles;
+    String topics;
 
     public BasicAuth(@Parameter String username) {
         this.username = username;

--- a/src/main/java/org/kafkahq/controllers/AbstractController.java
+++ b/src/main/java/org/kafkahq/controllers/AbstractController.java
@@ -19,6 +19,7 @@ import org.kafkahq.modules.KafkaModule;
 import javax.inject.Inject;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.Principal;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -41,7 +42,7 @@ abstract public class AbstractController {
     List<String> defaultRoles;
 
     @Inject
-    private List<BasicAuth> auths;
+    protected List<BasicAuth> auths;
 
     @SuppressWarnings("unchecked")
     protected Map templateData(Optional<String> cluster, Object... values) {
@@ -143,6 +144,20 @@ abstract public class AbstractController {
                 .map(authentication -> (List<String>) authentication.getAttributes().get("roles"))
                 .orElseGet(() -> this.defaultRoles)
         );
+    }
+
+    protected Optional<String> topicRegexFromUser(Principal user) {
+
+        Optional<String> regex = Optional.empty();
+
+        if(user != null){
+            Optional<BasicAuth> auth = this.auths.stream().filter(e -> e.getUsername().equals(user.getName())).findFirst();
+            if(auth.isPresent()){
+                regex = Optional.of(auth.get().getTopics());
+            }
+        }
+
+        return regex;
     }
 
     @Builder

--- a/src/main/java/org/kafkahq/repositories/AbstractRepository.java
+++ b/src/main/java/org/kafkahq/repositories/AbstractRepository.java
@@ -25,4 +25,12 @@ abstract public class AbstractRepository {
 
         return count == split.length;
     }
+
+    public static boolean isTopicMatchRegex(Optional<String> regex, String value){
+        if(!regex.isPresent()){
+            return true;
+        }
+
+        return value.matches(regex.get());
+    }
 }

--- a/src/main/java/org/kafkahq/repositories/TopicRepository.java
+++ b/src/main/java/org/kafkahq/repositories/TopicRepository.java
@@ -44,13 +44,13 @@ public class TopicRepository extends AbstractRepository {
         HIDE_STREAM,
     }
 
-    public List<CompletableFuture<Topic>> list(TopicListView view, Optional<String> search) throws ExecutionException, InterruptedException {
+    public List<CompletableFuture<Topic>> list(TopicListView view, Optional<String> search, Optional<String> topicsRegex) throws ExecutionException, InterruptedException {
         ArrayList<String> list = new ArrayList<>();
 
         Collection<TopicListing> listTopics = kafkaWrapper.listTopics();
 
         for (TopicListing item : listTopics) {
-            if (isSearchMatch(search, item.name()) && isListViewMatch(view, item.name())) {
+            if (isSearchMatch(search, item.name()) && isTopicMatchRegex(topicsRegex, item.name()) && isListViewMatch(view, item.name())) {
                 list.add(item.name());
             }
         }


### PR DESCRIPTION
Hi ! 
I've started to work on this feature. The idea is to provide a way to filter the topics that a user can see when he connects to kafkaHQ.
With this, we will be able to create a dedicated account to each team, with a limited view and rights.
I've been asked for this, and I really thinks it's a usefull one.
Do you agree ?

However, I've got a little problem. I've been able to secure the topic search service. And actually I'm able to detect when opening the topic page that the current user isn't authorized, but as it's a micronaut view, I can't redirect like it's already done (with a HttpResponse.redirect).
Do you have any idea ?
