### PR TITLE
Init helm chart

### DIFF
--- a/helm/chart/.helmignore
+++ b/helm/chart/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm/chart/Chart.yaml
+++ b/helm/chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for KafkaHQ on Kubernetes
+name: kafkahq
+version: 0.1.0

--- a/helm/chart/README.md
+++ b/helm/chart/README.md
@@ -1,0 +1,25 @@
+# Helm for KafkaHQ
+
+## Install Chart
+To install the KafkaHQ Chart into your Kubernetes cluster :
+
+```bash
+helm install --namespace "kafkahq" --name "kafkahq" kafkahq
+```
+
+After installation succeeds, you can get a status of Chart
+
+```bash
+helm status "kafkahq"
+```
+
+If you want to delete your Chart, use this command:
+
+```bash
+helm delete  --purge "kafkahq"
+```
+
+## Configuration
+Application configuration is in `templates/kafkahq-configmap.yaml`
+
+Others are presented in `values.yaml`

--- a/helm/chart/templates/NOTES.txt
+++ b/helm/chart/templates/NOTES.txt
@@ -1,0 +1,3 @@
+This chart installs KafkaHQ.
+
+https://github.com/tchiotludo/kafkahq

--- a/helm/chart/templates/_helpers.tpl
+++ b/helm/chart/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kafkahq.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kafkahq.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kafkahq.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/chart/templates/deployment.yaml
+++ b/helm/chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kafkahq.fullname" . }}

--- a/helm/chart/templates/deployment.yaml
+++ b/helm/chart/templates/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "kafkahq.fullname" . }}
+  labels:
+    app: {{ template "kafkahq.name" . }}
+    chart: {{ template "kafkahq.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "kafkahq.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/kafkahq-configmap.yaml") . | sha256sum }}
+        {{- if .Values.prometheus.enabled }}
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '{{ .Values.prometheus.port }}'
+        prometheus.io/path: '{{ .Values.prometheus.path }}'
+        {{- end }}
+      labels:
+        app: {{ template "kafkahq.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: {{ template "kafkahq.name" . }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        # https://github.com/tchiotludo/kafkahq/blob/0.9.0/docker/app/jvm.options
+        command:
+        - java
+        - -server
+        - -Dfile.encoding=UTF-8
+        - -Djava.awt.headless=true
+        - -XX:+HeapDumpOnOutOfMemoryError
+        - -Dfile.encoding=UTF-8
+        - -Duser.timezone=UTC
+        - -Dmicronaut.config.files=/etc/kafkahq/application.yml
+        - -Dcom.sun.management.jmxremote
+        - -Dcom.sun.management.jmxremote.port=8686
+        - -Dcom.sun.management.jmxremote.local.only=false
+        - -Dcom.sun.management.jmxremote.authenticate=false
+        - -Dcom.sun.management.jmxremote.ssl=false
+        - -jar
+        - kafkahq.jar
+        env:
+          - name: "_JAVA_OPTIONS"
+            value: {{ toYaml .Values.jvmOptions | trimSuffix "\n" | quote }}
+        ports:
+          - name: server
+            containerPort: {{ .Values.servicePort}}
+            protocol: TCP
+        volumeMounts:
+        - name: kafkahq-config
+          mountPath: /etc/kafkahq
+        readinessProbe:
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          failureThreshold: 24
+          httpGet:
+            path: /health
+            port: server
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+      volumes:
+      - name: kafkahq-config
+        configMap:
+          name: {{ template "kafkahq.fullname" . }}-kafkahq-configmap
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}

--- a/helm/chart/templates/ingress.yaml
+++ b/helm/chart/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "kafkahq.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/helm/chart/templates/ingress.yaml
+++ b/helm/chart/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "kafkahq.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ include "kafkahq.name" . }}
+    chart: {{ include "kafkahq.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: server
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/chart/templates/kafkahq-configmap.yaml
+++ b/helm/chart/templates/kafkahq-configmap.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "kafkahq.fullname" . }}-kafkahq-configmap
+  labels:
+    app: {{ template "kafkahq.name" . }}
+    chart: {{ template "kafkahq.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  application.yml: |+
+     kafkahq:
+        server:
+          access-log: # Access log configuration (optional)
+            enabled: true # true by default
+            name: org.kafkahq.log.access # Logger name
+            format: "[Date: {}] [Duration: {} ms] [Url: {} {} {}] [Status: {}] [Ip: {}] [Length: {}] [Port: {}]" # Logger format
+
+        # default kafka properties for each clients, available for admin / producer / consumer (optional)
+        clients-defaults:
+          consumer:
+            properties:
+              isolation.level: read_committed
+
+        # list of kafka cluster available for kafkahq
+        connections:
+          kafka-server: # url friendly name for the cluster (letter, number, _, -, ... dot are not allowed here)
+            properties: # standard kafka properties (optional)
+              bootstrap.servers: {{ .Values.kafka.bootstrapServers }}
+            {{ if .Values.schemaRegistry.url }}
+            schema-registry:
+              url: {{ .Values.schemaRegistry.url }}
+            {{ end }}
+            {{ if .Values.connect.url }}
+            connect:
+              url: {{ .Values.connect.url }}
+            {{ end }}
+        # Topic list display options (optional)
+        topic:
+          page-size: 15 # number of topics per page (default : 25)
+          default-view: {{ .Values.topic.defaultView }} # default list view (ALL, HIDE_INTERNAL, HIDE_INTERNAL_STREAM, HIDE_STREAM)
+          internal-regexps: # list of regexp to be considered as internal (internal topic can't be deleted or updated)
+            - "^_.*$"
+            - "^.*_schemas$"
+            - "^.*connect-config$"
+            - "^.*connect-offsets$1"
+            - "^.*connect-status$"
+          stream-regexps: # list of regexp to be considered as internal stream topic
+            - "^.*-changelog$"
+            - "^.*-repartition$"
+            - "^.*-rekey$"
+
+        # Topic display data options (optional)
+        topic-data:
+          sort: OLDEST # default sort order (OLDEST, NEWEST) (default: OLDEST)
+          size: 30 # max record per page (default: 50)
+          poll-timeout: 1000 # The time, in milliseconds, spent waiting in poll if data is not available in the buffer.
+
+        {{ if .Values.readOnly }}
+        security:
+          default-roles:
+            - topic/read
+            - node/read
+            - topic/data/read
+            - group/read
+            - registry/read
+            - connect/read
+        {{ end }}

--- a/helm/chart/templates/service.yaml
+++ b/helm/chart/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kafkahq.fullname" . }}
+  labels:
+    app: {{ template "kafkahq.name" . }}
+    chart: {{ template "kafkahq.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+      - name: kafka-hq
+        port: {{ .Values.servicePort }}
+  selector:
+    app: {{ template "kafkahq.name" . }}
+    release: {{ .Release.Name }}

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -1,0 +1,69 @@
+replicaCount: 1
+
+image: tchiotludo/kafkahq
+imageTag: 0.9.0
+
+## Specify a imagePullPolicy
+## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+imagePullPolicy: IfNotPresent
+
+## Specify an array of imagePullSecrets.
+## Secrets must be manually created in the namespace.
+## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+imagePullSecrets:
+
+servicePort: 8080
+
+ingress:
+  enabled: false
+  annotations: {}
+  hosts: {}
+  tls: {}
+
+jvmOptions: ""
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  #limits:
+    #cpu: 100m
+    #memory: 128Mi
+  #requests:
+    #cpu: 100m
+    #memory: 128Mi
+
+## Custom pod annotations
+podAnnotations: {}
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+nodeSelector: {}
+
+## Taints to tolerate on node assignment:
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: {}
+
+# Prometheus configuration
+prometheus:
+  enabled: true
+  port: 8080
+  path: /prometheus
+
+# https://github.com/tchiotludo/kafkahq#configuration
+kafka:
+  bootstrapServers: ""
+
+## e.g. gnoble-panther-cp-schema-registry:8081
+schemaRegistry:
+  url: ""
+
+connect:
+  url: ""
+
+# default list view (ALL, HIDE_INTERNAL, HIDE_INTERNAL_STREAM, HIDE_STREAM)
+topic:
+  defaultView: HIDE_INTERNAL_STREAM
+
+readOnly: false


### PR DESCRIPTION
One issue is `kafkahq-configmap` that is not very flexible to set and it's better to have more in values.yaml, and I would appreciate some suggestions to shift more to `values.yaml`

https://github.com/tchiotludo/kafkahq/issues/96