### PR TITLE
Added topic regex filter to basic auth users

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ repositories {
 }
 
 lombok {
-    version = '1.18.8'
+    version = '1.18.10'
     sha256 = ""
 }
 
@@ -85,8 +85,8 @@ configurations {
 
 run.classpath += configurations.developmentOnly
 test.classpath += configurations.developmentOnly
-run.jvmArgs('-noverify', 
-        '-XX:TieredStopAtLevel=1', 
+run.jvmArgs('-noverify',
+        '-XX:TieredStopAtLevel=1',
         '-Dmicronaut.environments=dev',
         '-Dmicronaut.io.watch.restart=true'
 )
@@ -147,6 +147,7 @@ dependencies {
     testCompile "org.junit.jupiter:junit-jupiter-api"
     testCompile "io.micronaut.test:micronaut-test-junit5"
     testRuntime "org.junit.jupiter:junit-jupiter-engine"
+    testCompile "org.mockito:mockito-junit-jupiter:3.1.0"
 
     // test
     testCompile "com.salesforce.kafka.test:kafka-junit5:3.1.1"

--- a/src/main/java/org/kafkahq/configs/BasicAuth.java
+++ b/src/main/java/org/kafkahq/configs/BasicAuth.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 
 @EachProperty("kafkahq.security.basic-auth")
 @Getter
@@ -14,6 +15,7 @@ public class BasicAuth {
     String username;
     String password;
     List<String> roles;
+    Map<String, Object> attributes;
 
     public BasicAuth(@Parameter String username) {
         this.username = username;

--- a/src/main/java/org/kafkahq/modules/BasicAuthAuthenticationProvider.java
+++ b/src/main/java/org/kafkahq/modules/BasicAuthAuthenticationProvider.java
@@ -19,8 +19,7 @@ public class BasicAuthAuthenticationProvider implements AuthenticationProvider {
         for(BasicAuth auth : auths) {
             if (authenticationRequest.getIdentity().equals(auth.getUsername()) &&
                 auth.isValidPassword((String) authenticationRequest.getSecret())) {
-                UserDetails userDetails = new UserDetails(auth.getUsername(), auth.getRoles());
-
+                UserDetails userDetails = new UserDetails(auth.getUsername(), auth.getRoles(), auth.getAttributes());
                 return Flowable.just(userDetails);
             }
         }

--- a/src/main/java/org/kafkahq/repositories/AbstractRepository.java
+++ b/src/main/java/org/kafkahq/repositories/AbstractRepository.java
@@ -17,4 +17,12 @@ abstract public class AbstractRepository {
 
         return count == split.length;
     }
+
+    public static boolean isTopicMatchRegex(Optional<String> regex, String topic){
+        if(!regex.isPresent()){
+            return true;
+        }
+
+        return topic.matches(regex.get());
+    }
 }

--- a/src/test/java/org/kafkahq/modules/BasicAuthAuthenticationProviderTest.java
+++ b/src/test/java/org/kafkahq/modules/BasicAuthAuthenticationProviderTest.java
@@ -19,7 +19,7 @@ public class BasicAuthAuthenticationProviderTest extends AbstractTest {
     BasicAuthAuthenticationProvider auth;
 
     @Test
-    public void sucess() {
+    public void success() {
         AuthenticationResponse response = Flowable
             .fromPublisher(auth.authenticate(new UsernamePasswordCredentials(
                 "user",
@@ -32,6 +32,8 @@ public class BasicAuthAuthenticationProviderTest extends AbstractTest {
 
         assertTrue(userDetail.isAuthenticated());
         assertEquals("user", userDetail.getUsername());
+        assertEquals("test.*", userDetail.getAttributes("roles", "user").get("topics"));
+
 
         Collection<String> roles = userDetail.getRoles();
 

--- a/src/test/java/org/kafkahq/repositories/TopicRepositoryTest.java
+++ b/src/test/java/org/kafkahq/repositories/TopicRepositoryTest.java
@@ -1,6 +1,13 @@
 package org.kafkahq.repositories;
 
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.security.authentication.Authentication;
+import io.micronaut.security.authentication.DefaultAuthentication;
+import io.micronaut.security.utils.DefaultSecurityService;
+import io.micronaut.security.utils.SecurityService;
 import org.apache.kafka.common.config.TopicConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.kafkahq.AbstractTest;
@@ -8,22 +15,39 @@ import org.kafkahq.KafkaClusterExtension;
 import org.kafkahq.KafkaTestCluster;
 import org.kafkahq.models.Config;
 import org.kafkahq.models.Partition;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 import javax.inject.Inject;
 import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(KafkaClusterExtension.class)
 public class TopicRepositoryTest extends AbstractTest {
+
     @Inject
+    @InjectMocks
     protected TopicRepository topicRepository;
 
     @Inject
     protected ConfigRepository configRepository;
+
+    @Mock
+    ApplicationContext applicationContext;
+
+    @BeforeEach
+    public void before(){
+        MockitoAnnotations.initMocks(this);
+    }
 
     @Test
     public void list() throws ExecutionException, InterruptedException {
@@ -46,21 +70,43 @@ public class TopicRepositoryTest extends AbstractTest {
     }
 
     @Test
+    public void listWithTopicRegex() throws ExecutionException, InterruptedException {
+        mockApplicationContext();
+        assertEquals(1, topicRepository.list(KafkaTestCluster.CLUSTER_ID, TopicRepository.TopicListView.ALL, Optional.empty()).size());
+    }
+
+    @Test
     public void search() throws ExecutionException, InterruptedException {
         assertEquals(1, topicRepository.list(KafkaTestCluster.CLUSTER_ID, TopicRepository.TopicListView.ALL, Optional.of("ra do")).size());
     }
 
     @Test
+    public void searchWithTopicRegex() throws ExecutionException, InterruptedException {
+        mockApplicationContext();
+        assertEquals(0, topicRepository.list(KafkaTestCluster.CLUSTER_ID, TopicRepository.TopicListView.ALL, Optional.of("stream")).size());
+    }
+
+    @Test
+    public void findByNameWithTopicRegex() throws ExecutionException, InterruptedException {
+        mockApplicationContext();
+        Assertions.assertThrows(NoSuchElementException.class, () -> {
+            topicRepository.findByName(KafkaTestCluster.CLUSTER_ID,"compacted");
+        });
+
+        assertEquals(1, topicRepository.findByName(KafkaTestCluster.CLUSTER_ID, List.of("compacted", "random")).size());
+    }
+
+    @Test
     public void create() throws ExecutionException, InterruptedException {
         topicRepository.create(KafkaTestCluster.CLUSTER_ID, "create", 8, (short) 1, Collections.singletonList(
-            new Config(TopicConfig.SEGMENT_MS_CONFIG, "1000")
+                new Config(TopicConfig.SEGMENT_MS_CONFIG, "1000")
         ));
 
         Optional<String> option = configRepository.findByTopic(KafkaTestCluster.CLUSTER_ID, "create")
-            .stream()
-            .filter(r -> r.getName().equals(TopicConfig.SEGMENT_MS_CONFIG))
-            .findFirst()
-            .map(Config::getValue);
+                .stream()
+                .filter(r -> r.getName().equals(TopicConfig.SEGMENT_MS_CONFIG))
+                .findFirst()
+                .map(Config::getValue);
 
         assertEquals(8, topicRepository.findByName(KafkaTestCluster.CLUSTER_ID, "create").getPartitions().size());
         assertEquals("1000", option.get());
@@ -71,11 +117,11 @@ public class TopicRepositoryTest extends AbstractTest {
     @Test
     public void offset() throws ExecutionException, InterruptedException {
         Optional<Partition> compacted = topicRepository
-            .findByName(KafkaTestCluster.CLUSTER_ID, KafkaTestCluster.TOPIC_COMPACTED)
-            .getPartitions()
-            .stream()
-            .filter(partition -> partition.getId() == 0)
-            .findFirst();
+                .findByName(KafkaTestCluster.CLUSTER_ID, KafkaTestCluster.TOPIC_COMPACTED)
+                .getPartitions()
+                .stream()
+                .filter(partition -> partition.getId() == 0)
+                .findFirst();
 
         assertTrue(compacted.isPresent());
         assertEquals(0, compacted.get().getFirstOffset());
@@ -85,5 +131,13 @@ public class TopicRepositoryTest extends AbstractTest {
     @Test
     public void partition() throws ExecutionException, InterruptedException {
         assertEquals(3, topicRepository.findByName(KafkaTestCluster.CLUSTER_ID, KafkaTestCluster.TOPIC_COMPACTED).getPartitions().size());
+    }
+
+    private void mockApplicationContext() {
+        Authentication auth = new DefaultAuthentication("test", Collections.singletonMap("topics", "rando.*"));
+        DefaultSecurityService securityService = Mockito.mock(DefaultSecurityService.class);
+        when(securityService.getAuthentication()).thenReturn(Optional.of(auth));
+        when(applicationContext.containsBean(SecurityService.class)).thenReturn(true);
+        when(applicationContext.getBean(SecurityService.class)).thenReturn(securityService);
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -26,6 +26,8 @@ kafkahq:
           - registry/version/delete
           - group/read
           - group/delete
+        attributes:
+          topics: "test.*"
 
 micronaut:
   caches:


### PR DESCRIPTION
Hey,

As discussed earlier in the year in #86 , the idea is to provide a way to filter the topics that a user can see when he connects to kafkaHQ.

The implementation is the following : 
If a topics regex is provided in the attributes, the user will be limited to the topics matching this regex. If no regex is provided, the user is able to see everything.