### PR TITLE
fixed the random error on the compacted topic tests #24

### DIFF
--- a/src/test/java/org/kafkahq/KafkaTestCluster.java
+++ b/src/test/java/org/kafkahq/KafkaTestCluster.java
@@ -70,7 +70,7 @@ public class KafkaTestCluster implements Runnable, Stoppable {
             .kafka("kafka:9092")
             .connect("http://connect:8083")
             .build();
-        
+
         testUtils = new KafkaTestUtils(new Provider(this.connectionString));
     }
 
@@ -214,8 +214,9 @@ public class KafkaTestCluster implements Runnable, Stoppable {
         testUtils.createTopic(TOPIC_COMPACTED, 3, (short) 1);
         testUtils.getAdminClient().alterConfigs(ImmutableMap.of(
             new ConfigResource(ConfigResource.Type.TOPIC, TOPIC_COMPACTED),
-            new Config(Collections.singletonList(
-                new ConfigEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT)
+            new Config(List.of(
+                new ConfigEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT),
+                new ConfigEntry(TopicConfig.MIN_CLEANABLE_DIRTY_RATIO_CONFIG, "0")
             ))
         )).all().get();
 


### PR DESCRIPTION
Hey,

Fixes #24 

I've successfully reproduced on my computer the error on the compacted topics (100% of time). I've found a solution which is to change one of the compacted topic config, so as to activate compaction quickly and be sure that logs are compacted when launching the unit tests.

Works 100% for me.