### PR TITLE
Fixes #81: Added the version to the kafkaHQ UI from the git property file

### DIFF
--- a/assets/modules/templates/sidebar.scss
+++ b/assets/modules/templates/sidebar.scss
@@ -15,10 +15,16 @@
         padding: 5px 10px;
         background: $tertiary;
         border-bottom: 4px solid $yellow;
+        position:relative;
         a {
             &:hover {
                 text-decoration: none;
             }
+        }
+        .version{
+            position:absolute;
+            right:5px;
+            bottom:0px;
         }
     }
 

--- a/src/main/java/org/kafkahq/controllers/AbstractController.java
+++ b/src/main/java/org/kafkahq/controllers/AbstractController.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.experimental.Wither;
 import org.kafkahq.configs.BasicAuth;
 import org.kafkahq.modules.KafkaModule;
+import org.kafkahq.utils.VersionProvider;
 
 import javax.inject.Inject;
 import java.net.URI;
@@ -32,6 +33,9 @@ abstract public class AbstractController {
     protected String basePath;
 
     @Inject
+    private VersionProvider versionProvider;
+
+    @Inject
     private KafkaModule kafkaModule;
 
     @Inject
@@ -47,6 +51,7 @@ abstract public class AbstractController {
     protected Map templateData(Optional<String> cluster, Object... values) {
         Map datas = CollectionUtils.mapOf(values);
 
+        datas.put("tag", versionProvider.getTag());
         datas.put("clusters", this.kafkaModule.getClustersList());
         datas.put("basePath", getBasePath());
         datas.put("roles", getRights());

--- a/src/main/java/org/kafkahq/utils/VersionProvider.java
+++ b/src/main/java/org/kafkahq/utils/VersionProvider.java
@@ -1,0 +1,34 @@
+package org.kafkahq.utils;
+
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.env.PropertiesPropertySourceLoader;
+import io.micronaut.core.util.StringUtils;
+import lombok.Getter;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Objects;
+
+@Singleton
+public class VersionProvider {
+
+    @Getter
+    private String tag = "Snapshot";
+
+    @Inject
+    Environment environment;
+
+    @PostConstruct
+    public void start() {
+        new PropertiesPropertySourceLoader()
+                .load("classpath:git", environment)
+                .ifPresent(properties -> setTag(properties.get("git.tags")));
+    }
+
+    private void setTag(Object value) {
+        String candidate = Objects.toString(value, null);
+        this.tag = StringUtils.isNotEmpty(candidate) ? candidate : this.tag;
+    }
+
+}

--- a/src/main/resources/views/includes/template.ftl
+++ b/src/main/resources/views/includes/template.ftl
@@ -40,6 +40,7 @@
                     <a href="${basePath}/">
                         <h3 class="logo"><img src="${basePath}/static/img/logo.svg" alt=""/><sup><strong>HQ</strong></sup></h3>
                     </a>
+                    <div class="version">${tag}</div>
                 </div>
 
                 <#if clusterId??>


### PR DESCRIPTION
Hi, 

In order to fix #81,

As we have the tag info into the git.properties, I've used it to display a version info on the ui.
Here is the result (It displays Snapshot if you're not on a tagged branch) :

![image](https://user-images.githubusercontent.com/43185161/66877252-114eb280-efb5-11e9-9b37-ffa2a420c3b9.png)

![image](https://user-images.githubusercontent.com/43185161/66877255-14e23980-efb5-11e9-8b33-f84fb6198a9f.png)

Sadly, we can't reuse the GitInfoSource class used by the info endpoint because it has a @Requires(beans = InfoEndpoint.class) annotation. 
The git.properties can't be called just by using a @Value. 

I've watched the GitInfoSource code and made a short version provider that read only one time the tag info and set it.

What do you think ? 
Oh and if you want the tag anywhere else instead of there, just tell me, it's just a proposal