### PR TITLE
WIP/RFC: Improving the performance of fetching topics and consumer groups

### DIFF
--- a/assets/modules/datas/search-sse.js
+++ b/assets/modules/datas/search-sse.js
@@ -18,7 +18,8 @@ $.widget("khq.search-sse", $.khq.widget, {
 
         this._eventSource = new EventSource(this._url()
             .clone()
-            .filename(this._url().filename() + "/search/" + this._url().search(true).search)
+            .segment('search')
+            .segmentCoded(this._url().search(true).search)
             .removeSearch("search")
             .toString()
         );

--- a/src/main/java/org/kafkahq/controllers/GroupController.java
+++ b/src/main/java/org/kafkahq/controllers/GroupController.java
@@ -26,7 +26,6 @@ import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 

--- a/src/main/java/org/kafkahq/controllers/GroupController.java
+++ b/src/main/java/org/kafkahq/controllers/GroupController.java
@@ -18,7 +18,7 @@ import org.kafkahq.models.TopicPartition;
 import org.kafkahq.modules.RequestHelper;
 import org.kafkahq.repositories.ConsumerGroupRepository;
 import org.kafkahq.repositories.RecordRepository;
-import org.kafkahq.utils.CompletablePaged;
+import org.kafkahq.utils.Paged;
 
 import javax.inject.Inject;
 import java.time.Instant;
@@ -49,10 +49,10 @@ public class GroupController extends AbstractController {
     @Get
     public HttpResponse list(HttpRequest request, String cluster, Optional<String> search, Optional<Integer> page) throws ExecutionException, InterruptedException {
 
-        List<CompletableFuture<ConsumerGroup>> list = this.consumerGroupRepository.list(cluster, search);
+        List<String> list = this.consumerGroupRepository.all(cluster, search);
         URIBuilder uri = URIBuilder.fromURI(request.getUri());
 
-        CompletablePaged<ConsumerGroup> paged = new CompletablePaged<>(
+        Paged<String> paged = new Paged<>(
             list,
             this.pageSize,
             uri,
@@ -63,7 +63,7 @@ public class GroupController extends AbstractController {
             request,
             cluster,
             "search", search,
-            "groups", paged.complete(),
+            "groups", this.consumerGroupRepository.findByName(cluster, paged.page()),
             "pagination", ImmutableMap.builder()
                 .put("size", paged.size())
                 .put("before", paged.before().toNormalizedURI(false).toString())

--- a/src/main/java/org/kafkahq/controllers/TopicController.java
+++ b/src/main/java/org/kafkahq/controllers/TopicController.java
@@ -27,7 +27,7 @@ import org.kafkahq.modules.RequestHelper;
 import org.kafkahq.repositories.ConfigRepository;
 import org.kafkahq.repositories.RecordRepository;
 import org.kafkahq.repositories.TopicRepository;
-import org.kafkahq.utils.CompletablePaged;
+import org.kafkahq.utils.Paged;
 import org.reactivestreams.Publisher;
 
 import javax.inject.Inject;
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.time.Instant;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -81,14 +80,14 @@ public class TopicController extends AbstractController {
         Optional<Integer> page
     ) throws ExecutionException, InterruptedException {
         TopicRepository.TopicListView topicListView = show.orElse(TopicRepository.TopicListView.valueOf(defaultView));
-        List<CompletableFuture<Topic>> list = this.topicRepository.list(
+        List<String> list = this.topicRepository.all(
             cluster,
             show.orElse(TopicRepository.TopicListView.valueOf(defaultView)),
             search
         );
 
         URIBuilder uri = URIBuilder.fromURI(request.getUri());
-        CompletablePaged<Topic> paged = new CompletablePaged<>(
+        Paged<String> paged = new Paged<>(
             list,
             this.pageSize,
             uri,
@@ -100,7 +99,7 @@ public class TopicController extends AbstractController {
             cluster,
             "search", search,
             "topicListView", topicListView,
-            "topics", paged.complete(),
+            "topics", this.topicRepository.findByName(cluster, paged.page()),
             "pagination", ImmutableMap.builder()
                 .put("size", paged.size())
                 .put("before", paged.before().toNormalizedURI(false).toString())

--- a/src/main/java/org/kafkahq/repositories/ConsumerGroupRepository.java
+++ b/src/main/java/org/kafkahq/repositories/ConsumerGroupRepository.java
@@ -15,7 +15,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/src/main/java/org/kafkahq/repositories/LogDirRepository.java
+++ b/src/main/java/org/kafkahq/repositories/LogDirRepository.java
@@ -8,8 +8,10 @@ import org.kafkahq.modules.KafkaWrapper;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -33,9 +35,15 @@ public class LogDirRepository extends AbstractRepository {
     }
 
     public List<LogDir> findByTopic(String clusterId, String topic) throws ExecutionException, InterruptedException {
+        Optional<List<LogDir>> logDirs = Optional.of(this.findByTopic(clusterId, Collections.singletonList(topic)).get(topic));
+
+        return logDirs.orElse(Collections.emptyList());
+    }
+
+    public Map<String, List<LogDir>> findByTopic(String clusterId, List<String> topics) throws ExecutionException, InterruptedException {
         return this.list(clusterId).stream()
-            .filter(item -> item.getTopic().equals(topic))
-            .collect(Collectors.toList());
+            .filter(item -> topics.contains(item.getTopic()))
+            .collect(Collectors.groupingBy(LogDir::getTopic));
     }
 
     public List<LogDir> findByBroker(String clusterId, Integer brokerId) throws ExecutionException, InterruptedException {

--- a/src/main/java/org/kafkahq/repositories/TopicRepository.java
+++ b/src/main/java/org/kafkahq/repositories/TopicRepository.java
@@ -124,6 +124,7 @@ public class TopicRepository extends AbstractRepository {
                 isInternal(topicDescription.name()),
                 isStream(topicDescription.name())
             ))
+            .sorted(Comparator.comparing(Topic::getName))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/org/kafkahq/repositories/TopicRepository.java
+++ b/src/main/java/org/kafkahq/repositories/TopicRepository.java
@@ -47,6 +47,9 @@ public class TopicRepository extends AbstractRepository {
     @Value("${kafkahq.topic.stream-regexps}")
     protected List<String> streamRegexps;
 
+    @Value("${kafkahq.topic.skip-consumer-groups:false}")
+    protected Boolean skipConsumerGroups;
+
     public enum TopicListView {
         ALL,
         HIDE_INTERNAL,
@@ -102,7 +105,9 @@ public class TopicRepository extends AbstractRepository {
         Collection<TopicDescription> topicDescriptions = kafkaWrapper.describeTopics(clusterId, topics).values();
         Map<String, List<Partition.Offsets>> topicOffsets = kafkaWrapper.describeTopicsOffsets(clusterId, topics);
 
-        Map<String, List<ConsumerGroup>> topicConsumerGroups = consumerGroupRepository.findByTopic(clusterId, topics);
+        Map<String, List<ConsumerGroup>> topicConsumerGroups = this.skipConsumerGroups
+            ? Collections.emptyMap()
+            : consumerGroupRepository.findByTopic(clusterId, topics);
         Map<String, List<LogDir>> topicLogDirs = logDirRepository.findByTopic(clusterId, topics);
 
         Optional<String> topicRegex = getTopicFilterRegex();

--- a/src/main/java/org/kafkahq/repositories/TopicRepository.java
+++ b/src/main/java/org/kafkahq/repositories/TopicRepository.java
@@ -8,6 +8,7 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.admin.TopicListing;
 import org.kafkahq.models.ConsumerGroup;
+import org.kafkahq.models.LogDir;
 import org.kafkahq.models.Partition;
 import org.kafkahq.models.Topic;
 import org.kafkahq.modules.KafkaModule;
@@ -111,6 +112,7 @@ public class TopicRepository extends AbstractRepository {
         Map<String, List<Partition.Offsets>> topicOffsets = kafkaWrapper.describeTopicsOffsets(clusterId, topics);
 
         Map<String, List<ConsumerGroup>> topicConsumerGroups = consumerGroupRepository.findByTopic(clusterId, topics);
+        Map<String, List<LogDir>> topicLogDirs = logDirRepository.findByTopic(clusterId, topics);
 
         Optional<String> topicRegex = getTopicFilterRegex();
 
@@ -120,7 +122,7 @@ public class TopicRepository extends AbstractRepository {
                     new Topic(
                         description.getValue(),
                         topicConsumerGroups.getOrDefault(description.getValue().name(), Collections.emptyList()),
-                        logDirRepository.findByTopic(clusterId, description.getValue().name()),
+                        topicLogDirs.getOrDefault(description.getValue().name(), Collections.emptyList()),
                         topicOffsets.get(description.getValue().name()),
                         isInternal(description.getValue().name()),
                         isStream(description.getValue().name())

--- a/src/main/java/org/kafkahq/repositories/TopicRepository.java
+++ b/src/main/java/org/kafkahq/repositories/TopicRepository.java
@@ -55,9 +55,7 @@ public class TopicRepository extends AbstractRepository {
     }
 
     public List<CompletableFuture<Topic>> list(String clusterId, TopicListView view, Optional<String> search) throws ExecutionException, InterruptedException {
-        List<String> topics = all(clusterId, view, search)
-            .stream()
-            .collect(Collectors.toList());
+        List<String> topics = all(clusterId, view, search);
 
         // XXX: The interface wants us to wrap these, so do that.
         return this.findByName(clusterId, topics)

--- a/src/main/java/org/kafkahq/repositories/TopicRepository.java
+++ b/src/main/java/org/kafkahq/repositories/TopicRepository.java
@@ -108,7 +108,7 @@ public class TopicRepository extends AbstractRepository {
     public List<Topic> findByName(String clusterId, List<String> topics) throws ExecutionException, InterruptedException {
         ArrayList<Topic> list = new ArrayList<>();
 
-        Set<Map.Entry<String, TopicDescription>> topicDescriptions = kafkaWrapper.describeTopics(clusterId, topics).entrySet();
+        Collection<TopicDescription> topicDescriptions = kafkaWrapper.describeTopics(clusterId, topics).values();
         Map<String, List<Partition.Offsets>> topicOffsets = kafkaWrapper.describeTopicsOffsets(clusterId, topics);
 
         Map<String, List<ConsumerGroup>> topicConsumerGroups = consumerGroupRepository.findByTopic(clusterId, topics);
@@ -116,16 +116,16 @@ public class TopicRepository extends AbstractRepository {
 
         Optional<String> topicRegex = getTopicFilterRegex();
 
-        for (Map.Entry<String, TopicDescription> description : topicDescriptions) {
-            if(isTopicMatchRegex(topicRegex, description.getValue().name())){
+        for (TopicDescription description : topicDescriptions) {
+            if (isTopicMatchRegex(topicRegex, description.name())) {
                 list.add(
                     new Topic(
-                        description.getValue(),
-                        topicConsumerGroups.getOrDefault(description.getValue().name(), Collections.emptyList()),
-                        topicLogDirs.getOrDefault(description.getValue().name(), Collections.emptyList()),
-                        topicOffsets.get(description.getValue().name()),
-                        isInternal(description.getValue().name()),
-                        isStream(description.getValue().name())
+                        description,
+                        topicConsumerGroups.getOrDefault(description.name(), Collections.emptyList()),
+                        topicLogDirs.getOrDefault(description.name(), Collections.emptyList()),
+                        topicOffsets.get(description.name()),
+                        isInternal(description.name()),
+                        isStream(description.name())
                     )
                 );
             }

--- a/src/main/java/org/kafkahq/repositories/TopicRepository.java
+++ b/src/main/java/org/kafkahq/repositories/TopicRepository.java
@@ -65,20 +65,15 @@ public class TopicRepository extends AbstractRepository {
     }
 
     public List<String> all(String clusterId, TopicListView view, Optional<String> search) throws ExecutionException, InterruptedException {
-        ArrayList<String> list = new ArrayList<>();
-
-        Collection<TopicListing> listTopics = kafkaWrapper.listTopics(clusterId);
-
-        for (TopicListing item : listTopics) {
-            if (isSearchMatch(search, item.name()) && isListViewMatch(view, item.name()) && isTopicMatchRegex(
-                getTopicFilterRegex(), item.name())) {
-                list.add(item.name());
-            }
-        }
-
-        list.sort(Comparator.comparing(String::toLowerCase));
-
-        return list;
+        return kafkaWrapper.listTopics(clusterId)
+            .stream()
+            .filter(item -> 
+                isSearchMatch(search, item.name())
+                && isListViewMatch(view, item.name())
+                && isTopicMatchRegex(getTopicFilterRegex(), item.name()))
+            .map(TopicListing::name)
+            .sorted(Comparator.comparing(String::toLowerCase))
+            .collect(Collectors.toList());
     }
 
     public boolean isListViewMatch(TopicListView view, String value) {

--- a/src/main/java/org/kafkahq/utils/CompletablePaged.java
+++ b/src/main/java/org/kafkahq/utils/CompletablePaged.java
@@ -1,6 +1,5 @@
 package org.kafkahq.utils;
 
-import lombok.AllArgsConstructor;
 import org.codehaus.httpcache4j.uri.URIBuilder;
 
 import java.util.List;
@@ -8,53 +7,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
-@AllArgsConstructor
-public class CompletablePaged <T> {
-    private List<CompletableFuture<T>> list;
-    private Integer pageSize;
-    private URIBuilder uri;
-    private Integer currentPage;
-
-    public int size() {
-        return this.list.size();
-    }
-
-    public URIBuilder before() {
-        if (currentPage - 1 > 0) {
-            return uri.addParameter("page", String.valueOf(currentPage - 1));
-        } else {
-            return URIBuilder.empty();
-        }
-    }
-
-    public URIBuilder after() {
-        if (currentPage + 1 <= this.pageCount()) {
-            return uri.addParameter("page", String.valueOf(currentPage + 1));
-        } else {
-            return URIBuilder.empty();
-        }
-    }
-
-    public int pageCount() {
-        return (this.list.size() / this.pageSize) + (this.list.size() % this.pageSize == 0 ? 0 : 1);
+public class CompletablePaged<T> extends Paged<CompletableFuture<T>> {
+    public CompletablePaged(List<CompletableFuture<T>> list, Integer pageSize, URIBuilder uri, Integer currentPage) {
+        super(list, pageSize, uri, currentPage);
     }
 
     public List<T> complete() throws ExecutionException, InterruptedException {
-        int start;
-        int end;
-
-        if (this.currentPage == 1) {
-            start = 0;
-            end = Math.min(this.pageSize, list.size());
-        } else if (this.currentPage == this.pageCount()) {
-            start = (this.currentPage - 1) * this.pageSize;
-            end = this.list.size();
-        } else {
-            start = (this.currentPage - 1) * this.pageSize;
-            end = (this.currentPage * this.pageSize);
-        }
-
-        List<CompletableFuture<T>> futuresList = list.subList(start, end);
+        List<CompletableFuture<T>> futuresList = this.page();
 
         list
             .stream()

--- a/src/main/java/org/kafkahq/utils/Paged.java
+++ b/src/main/java/org/kafkahq/utils/Paged.java
@@ -1,0 +1,57 @@
+package org.kafkahq.utils;
+
+import lombok.AllArgsConstructor;
+import org.codehaus.httpcache4j.uri.URIBuilder;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+@AllArgsConstructor
+public class Paged<T> {
+    protected List<T> list;
+    private Integer pageSize;
+    private URIBuilder uri;
+    private Integer currentPage;
+
+    public int size() {
+        return this.list.size();
+    }
+
+    public URIBuilder before() {
+        if (currentPage - 1 > 0) {
+            return uri.addParameter("page", String.valueOf(currentPage - 1));
+        } else {
+            return URIBuilder.empty();
+        }
+    }
+
+    public URIBuilder after() {
+        if (currentPage + 1 <= this.pageCount()) {
+            return uri.addParameter("page", String.valueOf(currentPage + 1));
+        } else {
+            return URIBuilder.empty();
+        }
+    }
+
+    public int pageCount() {
+        return (this.list.size() / this.pageSize) + (this.list.size() % this.pageSize == 0 ? 0 : 1);
+    }
+
+    public List<T> page() throws ExecutionException, InterruptedException {
+        int start;
+        int end;
+
+        if (this.currentPage == 1) {
+            start = 0;
+            end = Math.min(this.pageSize, list.size());
+        } else if (this.currentPage == this.pageCount()) {
+            start = (this.currentPage - 1) * this.pageSize;
+            end = this.list.size();
+        } else {
+            start = (this.currentPage - 1) * this.pageSize;
+            end = (this.currentPage * this.pageSize);
+        }
+
+        return list.subList(start, end);
+    }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -38,4 +38,5 @@
     </root>
 
     <logger name="org.apache" level="WARN" />
+    <logger name="org.kafkahq" level="TRACE" />
 </configuration>


### PR DESCRIPTION
I found KafkaHQ quite nice -- but it is way too slow and times out even with a "small" local setup of our environment. 

Looking a bit at the trace logging and the code I found a few places that definitely could be improved:
* TopicRepository was fetching all topics and then filtering them
* ConsumerGroupRepository was similar, and additionally also did that when looking up offsets

The linked commits "help" (my local setup is now nice and fast to load the `/:cluster/topic` page), but it still times out in my test production setup with a few hundred consumer groups. Ultimately I do want this to work on my production setup, which has similar amounts of consumer groups, but considerably more topics distributed over these groups.