### PR TITLE
add dependency to fix build error on connector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,6 +161,7 @@ dependencies {
     testCompile group: "io.confluent", name: "kafka-streams-avro-serde", version: confluentVersion
     testCompile "io.confluent:kafka-connect-avro-converter:" + confluentVersion
     testCompile group: 'commons-codec', name: 'commons-codec', version: '1.12'
+    testCompile group: 'org.codehaus.jackson', name: 'jackson-mapper-lgpl', version: '1.9.3'
     testImplementation 'org.hamcrest:hamcrest:2.1'
     testImplementation 'org.hamcrest:hamcrest-library:2.1'
 }


### PR DESCRIPTION
Add jackson dependency to tests compilation to fix NoClassDefFoundError.

Error:
java.lang.NoClassDefFoundError: org/codehaus/jackson/JsonNode
	at io.confluent.connect.avro.AvroConverter.configure(AvroConverter.java:71)