### PR TITLE
Build the search URL using segments

### DIFF
--- a/assets/modules/datas/search-sse.js
+++ b/assets/modules/datas/search-sse.js
@@ -18,7 +18,8 @@ $.widget("khq.search-sse", $.khq.widget, {
 
         this._eventSource = new EventSource(this._url()
             .clone()
-            .filename(this._url().filename() + "/search/" + this._url().search(true).search)
+            .segment('search')
+            .segmentCoded(this._url().search(true).search)
             .removeSearch("search")
             .toString()
         );


### PR DESCRIPTION
This fixes problems with the missing encoding of the path parameter, and at the same time avoids doing
string manipulation on things we know already what they are ("URL path segments"). URI.js does a good
job of combining these as needed already.

---
Reproduction case: Try search for something like `user/created`, which should produce a URL looking like `.../search/user%2fcreated`. Before this fix it would produce `.../search/user/created`, which (rightfully) returns a 401/404.