### PR TITLE
Show a question circle icon if the type of the connector is not present

### DIFF
--- a/src/main/resources/views/connectList.ftl
+++ b/src/main/resources/views/connectList.ftl
@@ -39,11 +39,15 @@
                 <tr>
                     <td>${connect.getName()}</td>
                     <td>
-                        <#if connect.getType() == "source">
-                            <i class="fa fa-forward" aria-hidden="true"></i>
-                        <#else>
-                            <i class="fa fa-backward" aria-hidden="true"></i>
-                        </#if>
+                        <#attempt>
+                            <#if connect.getType() == "source">
+                                <i class="fa fa-forward" aria-hidden="true"></i>
+                            <#else>
+                                <i class="fa fa-backward" aria-hidden="true"></i>
+                            </#if>
+                        <#recover>
+                            <i class="fa fa-question-circle" aria-hidden="true"></i>
+                        </#attempt>
                         ${connect.getShortClassName()}
                     </td>
                     <td>


### PR DESCRIPTION
If the connect API does not return the type of the connector (this can happen with old kafka connect deployments" an error was shown in the browser