### PR TITLE
Workaround for SR-ISSUE-1197: Remove RestServiceCache 

### DIFF
--- a/src/main/java/org/kafkahq/modules/KafkaModule.java
+++ b/src/main/java/org/kafkahq/modules/KafkaModule.java
@@ -134,39 +134,33 @@ public class KafkaModule {
         return this.producers.get(clusterId);
     }
 
-    private Map<String, RestService> registryRestClient = new HashMap<>();
-
     public RestService getRegistryRestClient(String clusterId) {
-        if (!this.registryRestClient.containsKey(clusterId)) {
-            Connection connection = this.getConnection(clusterId);
+        Connection connection = this.getConnection(clusterId);
 
-            if (connection.getSchemaRegistry() != null) {
-                RestService restService = new RestService(
-                    connection.getSchemaRegistry().getUrl().toString()
-                );
+        if (connection.getSchemaRegistry() != null) {
+            RestService restService = new RestService(
+                connection.getSchemaRegistry().getUrl().toString()
+            );
 
-                if (connection.getSchemaRegistry().getBasicAuthUsername() != null) {
-                    BasicAuthCredentialProvider basicAuthCredentialProvider = BasicAuthCredentialProviderFactory
-                        .getBasicAuthCredentialProvider(
-                            new UserInfoCredentialProvider().alias(),
-                            ImmutableMap.of(
-                                "schema.registry.basic.auth.user.info",
-                                connection.getSchemaRegistry().getBasicAuthUsername() + ":" +
-                                    connection.getSchemaRegistry().getBasicAuthPassword()
-                            )
-                        );
-                    restService.setBasicAuthCredentialProvider(basicAuthCredentialProvider);
-                }
-
-                if (connection.getSchemaRegistry().getProperties() != null) {
-                    restService.configure(connection.getSchemaRegistry().getProperties());
-                }
-
-                this.registryRestClient.put(clusterId, restService);
+            if (connection.getSchemaRegistry().getBasicAuthUsername() != null) {
+                BasicAuthCredentialProvider basicAuthCredentialProvider = BasicAuthCredentialProviderFactory
+                    .getBasicAuthCredentialProvider(
+                        new UserInfoCredentialProvider().alias(),
+                        ImmutableMap.of(
+                            "schema.registry.basic.auth.user.info",
+                            connection.getSchemaRegistry().getBasicAuthUsername() + ":" +
+                                connection.getSchemaRegistry().getBasicAuthPassword()
+                        )
+                    );
+                restService.setBasicAuthCredentialProvider(basicAuthCredentialProvider);
             }
-        }
 
-        return this.registryRestClient.get(clusterId);
+            if (connection.getSchemaRegistry().getProperties() != null) {
+                restService.configure(connection.getSchemaRegistry().getProperties());
+            }
+            return restService;
+        }
+        return null;
     }
 
     private Map<String, SchemaRegistryClient> registryClient = new HashMap<>();


### PR DESCRIPTION
SchemaRegistryClient mix credential of different schema-registry ... 

https://github.com/confluentinc/schema-registry/commit/d13ec241a228c88663001fb073ec6b9d1b9a770d#diff-eb120d0f1743614cb2d73575ee0a43ca

You can reproduce it with:
- 2 connections with 2 sr with different credential in your config
- Go to the first connection > schema registry > list ok
- Go to the second connection > schema registry > list ok
- Go to the first connection again > schema registry > 401 error

In debug mode, first connection to SR have credential of the second connection SR

Waiting for the release of SR, the workaround is to disable RestService Cache and recreate RestService everytime it is called. Not a big deal for KafkaHq
