### PR TITLE
Use more common units and names for expressing file size

### DIFF
--- a/src/main/resources/views/includes/functions.ftl
+++ b/src/main/resources/views/includes/functions.ftl
@@ -4,7 +4,7 @@
     <#assign order = num?round?c?length />
     <#assign thousands = ((order - 1) / 3)?floor />
     <#if (thousands < 0)><#assign thousands = 0 /></#if>
-    <#assign siMap = [ {"factor": 1, "unit": " b"}, {"factor": 1000, "unit": " ko"}, {"factor": 1000000, "unit": " mo"}, {"factor": 1000000000, "unit":" go"}, {"factor": 1000000000000, "unit": " to"} ]/>
+    <#assign siMap = [ {"factor": 1, "unit": " B"}, {"factor": 1024, "unit": " KiB"}, {"factor": 1024 * 1024, "unit": " MiB"}, {"factor": 1024 * 1024 * 1024, "unit":" GiB"}, {"factor": 1024 * 1024 * 1024 * 1024, "unit": " TiB"} ]/>
     <#assign siStr = (num / (siMap[thousands].factor))?string("0.#") + siMap[thousands].unit />
     <#return siStr />
 </#function>

--- a/src/main/resources/views/topicList.ftl
+++ b/src/main/resources/views/topicList.ftl
@@ -31,8 +31,8 @@
         <thead class="thead-dark">
             <tr>
                 <th class="text-nowrap">Name</th>
+                <th class="text-nowrap">Count</th>
                 <th class="text-nowrap">Size</th>
-                <th class="text-nowrap">Weight</th>
                 <th class="text-nowrap">Total</th>
                 <!--
                 <th class="text-nowrap">Available</th>


### PR DESCRIPTION
* Use 'Size' instead of 'Weight' in the topic list UI, and rename the existing column to 'Count'
* Use SI binary units (B, Kibibyte, Mebibyte, ...) instead of the 1000/octet-based numbers

---
Expressing a file "weight" in "octets" is quite common in the French locale, but this is rather confusing for English -- where it is a file "size" in "bytes". This commit tries to change to the binary SI units as per https://en.wikipedia.org/wiki/Byte.