### PR TITLE
Role assignments to individual LDAP users

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ Dev server is a java server & webpack-dev-server with live reload.
 * [Adeo](https://www.adeo.com/)
 * [Auchan Retail](https://www.auchan-retail.com/)
 * [Bell](https://www.bell.ca)
+* [BMW Group](https://www.bmwgroup.com)
 * [Boulanger](https://www.boulanger.com/)
 * [GetYourGuide](https://www.getyourguide.com)
 * [La Redoute](https://laredoute.io/)

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ micronaut:
           base: "dc=example,dc=com"
 ```
 
-Configure KafkaHQ groups and Ldap groups
+Configure KafkaHQ groups and Ldap groups and users
 ```yaml
 kafkahq:
   security:
@@ -323,6 +323,12 @@ kafkahq:
           groups:
             - topic-reader
             - topic-writer
+      user:
+        franz:
+          groups:
+            - topic-reader
+            - topic-writer
+
 ```
 
 ### Server 

--- a/application.example.yml
+++ b/application.example.yml
@@ -172,3 +172,10 @@ kafkahq:
         group-ldap-2:
           groups:
             - admin
+      user:
+        riemann: # ldap user id
+          groups: # KafkaHQ groups list
+            - topic-reader
+        einstein:
+          groups:
+            - admin

--- a/src/main/java/org/kafkahq/configs/LdapUser.java
+++ b/src/main/java/org/kafkahq/configs/LdapUser.java
@@ -1,0 +1,18 @@
+package org.kafkahq.configs;
+
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+import lombok.Getter;
+
+import java.util.List;
+
+@EachProperty("kafkahq.security.ldap.user")
+@Getter
+public class LdapUser {
+    String username;
+    List<String> groups;
+
+    public LdapUser(@Parameter String username) {
+	this.username = username;
+    }
+}

--- a/src/main/java/org/kafkahq/controllers/AbstractController.java
+++ b/src/main/java/org/kafkahq/controllers/AbstractController.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.experimental.Wither;
 import org.kafkahq.configs.BasicAuth;
 import org.kafkahq.configs.LdapGroup;
+import org.kafkahq.configs.LdapUser;
 import org.kafkahq.modules.KafkaModule;
 import org.kafkahq.utils.UserGroupUtils;
 import org.kafkahq.utils.VersionProvider;
@@ -56,6 +57,9 @@ abstract public class AbstractController {
     @Inject
     private List<LdapGroup> ldapAuths;
 
+    @Inject
+    private List<LdapUser> ldapUsers;
+
     @SuppressWarnings("unchecked")
     protected Map templateData(Optional<String> cluster, Object... values) {
         Map datas = CollectionUtils.mapOf(values);
@@ -77,7 +81,7 @@ abstract public class AbstractController {
         });
 
         if (applicationContext.containsBean(SecurityService.class)) {
-            datas.put("loginEnabled", basicAuths.size() > 0 || ldapAuths.size() > 0);
+            datas.put("loginEnabled", basicAuths.size() > 0 || ldapAuths.size() > 0 || ldapUsers.size() > 0);
 
             SecurityService securityService = applicationContext.getBean(SecurityService.class);
             securityService

--- a/src/main/java/org/kafkahq/modules/LdapContextAuthenticationMapper.java
+++ b/src/main/java/org/kafkahq/modules/LdapContextAuthenticationMapper.java
@@ -7,6 +7,7 @@ import io.micronaut.core.convert.value.ConvertibleValues;
 import io.micronaut.security.authentication.AuthenticationResponse;
 import io.micronaut.security.authentication.UserDetails;
 import org.kafkahq.configs.LdapGroup;
+import org.kafkahq.configs.LdapUser;
 import org.kafkahq.utils.UserGroupUtils;
 
 import javax.inject.Inject;
@@ -14,6 +15,7 @@ import javax.inject.Singleton;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Singleton
 @Replaces(DefaultContextAuthenticationMapper.class)
@@ -23,12 +25,14 @@ public class LdapContextAuthenticationMapper implements ContextAuthenticationMap
     private List<LdapGroup> kafkaHQLdapGroups;
 
     @Inject
+    private List<LdapUser> kafkaHQLdapUsers;
+
+    @Inject
     private UserGroupUtils userGroupUtils;
 
     @Override
     public AuthenticationResponse map(ConvertibleValues<Object> attributes, String username, Set<String> groups) {
-
-        List<String> kafkaHQgroups = getUserKafkaHQGroups(groups);
+        List<String> kafkaHQgroups = getUserKafkaHQGroups(username, groups);
         return new UserDetails(username, userGroupUtils.getUserRoles(kafkaHQgroups), userGroupUtils.getUserAttributes(kafkaHQgroups));
     }
 
@@ -37,12 +41,16 @@ public class LdapContextAuthenticationMapper implements ContextAuthenticationMap
      * @param ldapGroups  list of ldap groups associated to the user
      * @return list of KafkaHQ groups configured for the ldap groups. See in application.yml property kafkahq.security.ldap
      */
-    private List<String> getUserKafkaHQGroups(Set<String> ldapGroups) {
-        return this.kafkaHQLdapGroups.stream()
-                .filter(ldapGroup -> ldapGroups.stream().map(String::toLowerCase).anyMatch(s -> s.equals(ldapGroup.getName().toLowerCase())) )
-                .flatMap(ldapGroup -> ldapGroup.getGroups().stream())
-                .distinct()
-                .collect(Collectors.toList());
-    }
+    private List<String> getUserKafkaHQGroups(String username, Set<String> ldapGroups) {
+        return Stream.concat(
+            this.kafkaHQLdapUsers.stream()
+                .filter(ldapUser -> username.equalsIgnoreCase(ldapUser.getUsername()))
+                .flatMap(ldapUser -> ldapUser.getGroups().stream()),
 
+            this.kafkaHQLdapGroups.stream()
+                .filter(ldapGroup -> ldapGroups.stream().map(String::toLowerCase).anyMatch(s -> s.equals(ldapGroup.getName().toLowerCase())))
+                .flatMap(ldapGroup -> ldapGroup.getGroups().stream()))
+
+            .distinct().collect(Collectors.toList());
+    }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -80,4 +80,7 @@ kafkahq:
         ldap-operator:
           groups:
             - operator
-
+      user:
+        user2:
+          groups:
+            - operator


### PR DESCRIPTION
Role assignments to individual LDAP users makes it possible to use LDAP purely for authentication, when defining LDAP groups is not wanted.

Role assignments from groups are merged together with individual role assignments. 

Description is added in README.md.